### PR TITLE
add Note.Tie for representing tied notes

### DIFF
--- a/mxl.go
+++ b/mxl.go
@@ -73,6 +73,7 @@ type Note struct {
 	Type     string   `xml:"type"`
 	Rest     xml.Name `xml:"rest"`
 	Chord    xml.Name `xml:"chord"`
+	Tie      Tie      `xml:"tie"`
 }
 
 // Pitch represents the pitch of a note
@@ -80,4 +81,9 @@ type Pitch struct {
 	Accidental int8   `xml:"alter"`
 	Step       string `xml:"step"`
 	Octave     int    `xml:"octave"`
+}
+
+// Tie represents whether or not a note is tied.
+type Tie struct {
+	Type string `xml:"type,attr"`
 }


### PR DESCRIPTION
These are in musicXML format when exported via e.g. MuseScore 2, typically `type="start"` and `type="stop"` are the only two type's I've seen.

Forking the repo here because the original author isn't active (see https://github.com/eliothedeman/go-mxl/pull/2)
